### PR TITLE
HGI-9851: Add support for synthetic replication keys and value templates in incremental syncs

### DIFF
--- a/TAP_DEFINITION_SCHEMA.md
+++ b/TAP_DEFINITION_SCHEMA.md
@@ -271,6 +271,8 @@ Configures incremental data synchronization based on a replication key.
     "state_datetime_format": "%m/%d/%Y %I:%M:%S %p",
     "location": "request_parameter",
     "embedded": true,
+    "value_template": "findByDate;auditDate={replication_key_value}",
+    "replication_key_sources": ["updated_at", "created_at"],
     "is_inclusive": true,
     "step": "P1D"
 }
@@ -288,6 +290,8 @@ Configures incremental data synchronization based on a replication key.
 | `location` | string | No | Where to include the date filter. Values: `"request_parameter"`, `"body"`, `"base_url"` |
 | `path` | string | No | JSONPath for nested placement in request body |
 | `embedded` | boolean | No | Whether the filter is embedded in custom query params |
+| `value_template` | string | No | When set, the parameter value is this string with `{replication_key_value}` replaced by the formatted date. Use when the API expects a composite value (e.g. `findByDate;auditDate={replication_key_value}`) instead of the raw date. |
+| `replication_key_sources` | array of strings | No | When set, the replication key is a synthetic field: each record gets `replication_key` = first non-null value from these source fields (e.g. `["updated_at", "created_at"]` for “updated or created”). Use when the API returns only one of the dates per record. Remember to include the synthetic field in the stream schema. |
 | `is_inclusive` | boolean | No | Whether the filter is inclusive (>=) or exclusive (>) |
 | `step` | string | No | ISO 8601 duration for stepping through date ranges (e.g., `"P1D"` for 1 day) |
 

--- a/tap_hotglue/client.py
+++ b/tap_hotglue/client.py
@@ -471,7 +471,7 @@ class HotglueStream(RESTStream):
 
         value_template = incremental_data.get("value_template")
         if value_template:
-            param_value = value_template.replace("{replication_key_value}", start_date)
+            param_value = value_template.replace("{replication_key_value}", str(start_date))
             return {incremental_data["field_name"]: param_value}
         return {incremental_data["field_name"]: start_date}
 
@@ -559,10 +559,12 @@ class HotglueStream(RESTStream):
             self.incremental_sync.get("datetime_format") in ["timestamp", "timestamp_ms"]
             or self.incremental_sync.get("state_datetime_format")
         ):
-            return self._process_datetime_fields(row)
+            row = self._process_datetime_fields(row)
+
         # Add time_extracted field if specified as rep key
         if self.incremental_sync and self.incremental_sync.get("replication_key") == "time_extracted":
             row["time_extracted"] = datetime.now().isoformat()
+
         # Synthetic replication key: coalesce from replication_key_sources (e.g. update or create date)
         replication_key_sources = self.incremental_sync and self.incremental_sync.get("replication_key_sources")
         if replication_key_sources:

--- a/tap_hotglue/client.py
+++ b/tap_hotglue/client.py
@@ -469,6 +469,10 @@ class HotglueStream(RESTStream):
         if self.incremental_sync.get("embedded"):
             self.replication_key_value = start_date
 
+        value_template = incremental_data.get("value_template")
+        if value_template:
+            param_value = value_template.replace("{replication_key_value}", start_date)
+            return {incremental_data["field_name"]: param_value}
         return {incremental_data["field_name"]: start_date}
 
     def get_url_params(
@@ -559,6 +563,18 @@ class HotglueStream(RESTStream):
         # Add time_extracted field if specified as rep key
         if self.incremental_sync and self.incremental_sync.get("replication_key") == "time_extracted":
             row["time_extracted"] = datetime.now().isoformat()
+        # Synthetic replication key: coalesce from replication_key_sources (e.g. update or create date)
+        replication_key_sources = self.incremental_sync and self.incremental_sync.get("replication_key_sources")
+        if replication_key_sources:
+            rep_key = self.incremental_sync.get("replication_key")
+            if rep_key:
+                for src in replication_key_sources:
+                    val = row.get(src)
+                    if val is not None and val != "":
+                        row[rep_key] = val
+                        break
+                else:
+                    row[rep_key] = None
         return row
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:


### PR DESCRIPTION
- Introduced `value_template` to format parameter values using `{replication_key_value}`.
- Added `replication_key_sources` to define synthetic fields for replication keys, allowing for coalescing of values from specified fields.
- Updated documentation to reflect these new configurations.